### PR TITLE
feat(hmpo): add REDIS_CONNECTION_STRING env

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -11,6 +11,7 @@ module.exports = {
       error: false
     },
     redis: {
+      connectionString: process.env.REDIS_CONNECTION_STRING ? `redis://${process.env.REDIS_CONNECTION_STRING}` : undefined,
       host: process.env.REDIS_HOST || undefined,
       port: process.env.REDIS_PORT || undefined
     },

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -7,8 +7,9 @@ services:
     environment:
       API_HOST: mock-api
       API_PORT: 8080
-      REDIS_HOST: redis-service
-      REDIS_PORT: 6379
+      REDIS_CONNECTION_STRING: "redis-service:6379"
+#      REDIS_HOST: redis-service
+#      REDIS_PORT: 6379
     depends_on:
     - redis-service
     - mock-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
     environment:
       API_HOST: mock-api
       API_PORT: 8080
-      REDIS_HOST: redis-service
-      REDIS_PORT: 6379
+      REDIS_CONNECTION_STRING: "redis-service:6379"
+#      REDIS_HOST: redis-service
+#      REDIS_PORT: 6379
     depends_on:
     - redis-service
     - mock-api


### PR DESCRIPTION
This PR allows Redis to be configured via the env REDIS_CONNECTION_STRING.

Jira: https://collaboration.homeoffice.gov.uk/jira/browse/DVAD-3550
