### PR TITLE
organisation create screen for lev-admin

### DIFF
--- a/controllers/UserManagement/OrganisationCreateController.js
+++ b/controllers/UserManagement/OrganisationCreateController.js
@@ -1,0 +1,52 @@
+const BaseController = require('../BaseController');
+const {postRequest} = require('../../services/UserManagement/UserActionsService');
+const teamPermissionsObjectBuilder = require('../../helpers/teamPermissionsObjectBuilder');
+
+class OrganisationCreateController extends BaseController {
+
+  async saveValues(req, res, next) {
+
+    // Get the values from the form
+    const organisationName = req.form.values['organisationName'];
+
+    try {
+      req.sessionModel.set('addOrgAttempt', true);
+
+      const orgResult = await postRequest({
+        ...this.getOptions(req),
+        url: '/admin/organisations',
+      }, { organisationName: organisationName });
+
+      const createdOrg = orgResult.organisation;
+
+      const defaultTeamName = 'Administrators';
+      const defaultTeamPermissions = ['birth', 'death', 'marriage', 'partnership', 'user-management' ];
+      const defaultTeamPermissionsObject= teamPermissionsObjectBuilder(defaultTeamPermissions, next);
+
+      await postRequest( {
+        ...this.getOptions(req),
+        url: `/admin/organisations/${createdOrg.id}/teams`,
+      }, { teamName: defaultTeamName, teamPermissions: defaultTeamPermissionsObject });
+
+      req.sessionModel.set('addOrgSuccess', true);
+
+    } catch (err) {
+      req.sessionModel.set('addOrgSuccess', false);
+      if (err.status === 409) {
+        req.sessionModel.set('orgExistsError', true);
+      }
+    }
+
+    req.sessionModel.set('addedOrgName', organisationName);
+    res.redirect('/admin/organisations');
+  }
+
+  locals(req, res, callback) {
+    super.locals(req, res, (error, locals) => {
+      if (error) return callback(error);
+      callback(null, locals);
+    });
+  }
+}
+
+module.exports = OrganisationCreateController;

--- a/controllers/UserManagement/OrganisationsController.js
+++ b/controllers/UserManagement/OrganisationsController.js
@@ -28,6 +28,15 @@ class OrganisationsController extends BaseController {
     super.locals(req, res, (error, locals) => {
       if (error) return callback(error);
       locals.orgsInfo = req.sessionModel.get('orgsResult') || [];
+      locals.IS_EXTERNAL = process.env.IS_EXTERNAL || 'true';
+      locals.addOrgAttempt = req.sessionModel.get('addOrgAttempt') || false;
+      locals.addOrgSuccess = req.sessionModel.get('addOrgSuccess') || false;
+      locals.addedOrgName = req.sessionModel.get('addedOrgName') || '';
+      locals.orgExistsError = req.sessionModel.get('orgExistsError') || false;
+      req.sessionModel.unset('addOrgAttempt');
+      req.sessionModel.unset('addOrgSuccess');
+      req.sessionModel.unset('addedOrgName');
+      req.sessionModel.unset('orgExistsError');
       callback(null, locals);
     });
   }

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -136,6 +136,9 @@
         }
       }
 
+    },
+    "organisationName": {
+      "label": "Organisation Name"
     }
   },
   "pages": {
@@ -210,6 +213,10 @@
       "organisationsPage": {
         "title": "Manage organisations",
         "pageTitle": "Manage organisations"
+      },
+      "organisationCreatePage": {
+        "title": "Add organisation",
+        "pageTitle": "Add organisation"
       },
       "teamPage": {
         "title": "Manage team",
@@ -393,6 +400,11 @@
     },
     "permissionCheckboxes": {
       "required": "Select one or more search permissions"
+    },
+    "organisationName": {
+      "required": "Enter organisation name",
+      "length": "Organisation name must be 255 characters or less",
+      "regex": "Organisation name can only include letters and spaces"
     }
   },
   "footer": "Your feedback will help us improve this service. Email us <a href=\"mailto:ITnowServiceDesk@homeoffice.gov.uk?subject=LEV%20Feedback\">ITnowServiceDesk@homeoffice.gov.uk</a>"

--- a/routes/organisation/fields.js
+++ b/routes/organisation/fields.js
@@ -37,15 +37,23 @@ module.exports = {
   },
   'permissionCheckboxes': {
     type: 'checkboxes',
-    classes: "govuk-checkboxes--small",
+    classes: 'govuk-checkboxes--small',
     items: [
-      { value: "birth" },
-      { value: "death" },
-      { value: "marriage"},
-      { value: "partnership"}
+      { value: 'birth' },
+      { value: 'death' },
+      { value: 'marriage'},
+      { value: 'partnership'}
     ],
     validate: [
       'required'
+    ]
+  },
+  'organisationName': {
+    type: 'text',
+    validate: [
+      'required',
+      { type: 'regex', arguments: '^[a-zA-Z ]+$'},
+      { type: 'length', fn: (e) => e.length >= 1 && e.length <= 255 }
     ]
   }
 };

--- a/routes/organisation/steps.js
+++ b/routes/organisation/steps.js
@@ -9,12 +9,12 @@ const DeleteUserController = require('../../controllers/UserManagement/DeleteUse
 const UserEditController = require('../../controllers/UserManagement/UserEditController');
 const ResetUserPasswordController = require('../../controllers/UserManagement/ResetUserPasswordController');
 const UserCreateController = require('../../controllers/UserManagement/UserCreateController');
+const OrganisationCreateController = require('../../controllers/UserManagement/OrganisationCreateController');
 
 const externalRoutes = {
   '/': {
     controller: OrganisationsController,
     entryPoint: true,
-    resetJourney: true,
     template: '/organisations.html',
     next: '/:orgId'
   },
@@ -60,15 +60,21 @@ const externalRoutes = {
     entryPoint: true,
     skip: true
   }
-}
+};
 
 const internalRoutes = {
+  '/create': {
+    fields: ['organisationName'],
+    controller: OrganisationCreateController,
+    entryPoint: true,
+    template: '/organisation-create.html'
+  },
   '/:orgId/team/create': {
-  controller: TeamCreateController,
+    controller: TeamCreateController,
     fields: ['teamName', 'permissionCheckboxes'],
     entryPoint: true,
     template: '/add-team.html'
   }
-}
+};
 
 module.exports = { externalRoutes, internalRoutes };

--- a/views/pages/organisation/organisation-create.html
+++ b/views/pages/organisation/organisation-create.html
@@ -1,0 +1,34 @@
+{% extends "app-template.njk" %}
+
+{% set govukServiceNameKey = translate("pages.user-management.serviceName") %}
+{% set govukServiceTitleKey = translate("pages.user-management.organisationCreatePage.pageTitle") %}
+{% set hmpoPageKey = "user-management.organisationCreatePage" %}
+{% set govukServiceUrl = "/admin/organisations" %}
+{% from "hmpo-text/macro.njk" import hmpoText %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
+{% from "hmpo-submit/macro.njk" import hmpoSubmit %}
+
+{% block hmpoContent %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        {% block mainContent %}
+        <h1 id="header" data-page="{{hmpoPageKey}}">{{ translate("pages." + hmpoPageKey + ".h1", { default: hmpoTitle }) |
+            safe }}</h1>
+        {% call hmpoForm(ctx) %}
+        {{ hmpoText(ctx, {
+            id: "organisationName",
+            label: {
+                text: translate("fields.organisationName.label"),
+                classes: "govuk-label--s"
+            }
+        }) }}
+        <div class="govuk-button-group">
+            {{ hmpoSubmit(ctx, {id: "submit", key: "submit"}) }}
+            {{ hmpoSubmit(ctx, {id: "back", key: "back", href: govukServiceUrl, classes: "govuk-button--secondary"}) }}
+        </div>
+        {% endcall %}
+
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}

--- a/views/pages/organisation/organisations.html
+++ b/views/pages/organisation/organisations.html
@@ -1,6 +1,8 @@
 {% extends "app-template.njk" %}
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set govukServiceNameKey = translate("pages.user-management.serviceName") %}
 {% set govukServiceTitleKey = translate("pages.user-management.organisationsPage.pageTitle") %}
@@ -11,23 +13,64 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         {% block mainContent %}
-        <h1 id="header" data-page="{{hmpoPageKey}}">{{ translate("pages." + hmpoPageKey + ".h1", { default: hmpoTitle }) | safe }}</h1>
+
+        <div class="govuk-grid-row">
+            <div class="govuk-!-width-two-thirds">
+
+                {% set status = '' %}
+                {% set html = '' %}
+
+                {% if addOrgAttempt %}
+                    {% if addOrgSuccess %}
+                        {% set status = "success" %}
+                        {% set html = "<h2>You have successfully added " + addedOrgName + " </h2>" %}
+                    {% else %}
+                        {% set status = "failure" %}
+                        {% if orgExistsError %}
+                            {% set html = "<h2>Unable to add organisation as " + addedOrgName + " already exists</h2>" %}
+                        {% else %}
+                            {% set html = "<h2>There is a problem - Unable to add organisation " + addedOrgName + "</h2>" %}
+                        {% endif %}
+                    {% endif %}
+
+                    {{ govukNotificationBanner({
+                    html: html,
+                    type: status
+                    }) }}
+                {% endif %}
+            </div>
+
+            <div class="govuk-grid-column-three-quarters">
+                <h1 id="header" data-page="{{hmpoPageKey}}">{{ translate("pages." + hmpoPageKey + ".h1", { default: hmpoTitle }) | safe }}</h1>
+            </div>
+
+            <div class="govuk-grid-column-one-quarter">
+                {% if IS_EXTERNAL == "false" %}
+                    {{ govukButton({
+                        text: "Add organisation",
+                        href: govukServiceUrl + "/create",
+                        classes: "govuk-button--secondary" })
+                    }}
+                {% endif %}
+            </div>
+        </div>
+
         {% set orgsHeaderArray = [{ text: "Organisation" }] %}
         {% set orgsArray = [] %}
 
         {% for org in orgsInfo %}
-        {% set rowArray = [] %}
-        {% set orgLink = "/admin/organisations/" + org.id %}
-        {% set rowArray = (rowArray.push( { html: "<a href=" + orgLink +">" + org.name + "</a>" } ), rowArray) %}
-        {% set orgsArray = (orgsArray.push(rowArray), orgsArray) %}
+            {% set rowArray = [] %}
+            {% set orgLink = "/admin/organisations/" + org.id %}
+            {% set rowArray = (rowArray.push( { html: "<a href=" + orgLink +">" + org.name + "</a>" } ), rowArray) %}
+            {% set orgsArray = (orgsArray.push(rowArray), orgsArray) %}
         {% endfor %}
 
-        <div class="table-horizontal-scrolling">
+        <div class="govuk-!-width-two-thirds">
             {{ govukTable({
-            classes: "audit",
-            firstCellIsHeader: true,
-            head: orgsHeaderArray,
-            rows: orgsArray
+                classes: "detail",
+                firstCellIsHeader: true,
+                head: orgsHeaderArray,
+                rows: orgsArray
             }) }}
         </div>
         {% endblock %}

--- a/views/pages/organisation/team.html
+++ b/views/pages/organisation/team.html
@@ -27,7 +27,7 @@
         {% if addedUser %}
           {% if userFullName %}
             {% set status = "success" %}
-            {% set html = "<h2>You have successfully added " + userFullName %}
+            {% set html = "<h2>You have successfully added " + userFullName + " </h2>" %}
           {% else %}
             {% set status = "failure" %}
             {% set html="<h2>" + errorMessage +"</h2>" %}


### PR DESCRIPTION
Create a new step `/create` for lev admin to be able to create organisation.
Remove `resetJourney` flag from `/` step so the sessionModel exists on Manage organisation screen and the success or failure notification are shown.
Created `OrganisationCreateController` to handle the request which is posting api request for both adding organisation and adding Administrator team.
To add Admin team, had to make changes for creating organisation api so it returns back the new created organisation and its orgId can be used to create admin team. 