### PR TITLE
changes to User create and edit controller to retrieve non admin teams only

### DIFF
--- a/controllers/UserManagement/UserCreateController.js
+++ b/controllers/UserManagement/UserCreateController.js
@@ -9,7 +9,7 @@ class UserCreateController extends BaseController {
     try {
       const orgTeamsResult = await orgLookup({
         ...this.getOptions(req),
-        url: `/admin/organisations/${req.params.orgId}/teams?removeAdmin=true`
+        url: `/admin/organisations/${req.params.orgId}/assignable-teams`
       });
 
       req.sessionModel.set('orgTeamsToSelect', orgTeamsResult);

--- a/controllers/UserManagement/UserCreateController.js
+++ b/controllers/UserManagement/UserCreateController.js
@@ -9,7 +9,7 @@ class UserCreateController extends BaseController {
     try {
       const orgTeamsResult = await orgLookup({
         ...this.getOptions(req),
-        url: `/admin/organisations/${req.params.orgId}/teams`
+        url: `/admin/organisations/${req.params.orgId}/teams?removeAdmin=true`
       });
 
       req.sessionModel.set('orgTeamsToSelect', orgTeamsResult);

--- a/controllers/UserManagement/UserEditController.js
+++ b/controllers/UserManagement/UserEditController.js
@@ -13,7 +13,7 @@ class UserEditController extends BaseController {
 
       const orgTeamsResult = await orgLookup({
         ...this.getOptions(req),
-        url: `/admin/organisations/${req.params.orgId}/teams?removeAdmin=true`
+        url: `/admin/organisations/${req.params.orgId}/assignable-teams`
       });
 
       req.sessionModel.set('userResults', userResults);

--- a/controllers/UserManagement/UserEditController.js
+++ b/controllers/UserManagement/UserEditController.js
@@ -13,7 +13,7 @@ class UserEditController extends BaseController {
 
       const orgTeamsResult = await orgLookup({
         ...this.getOptions(req),
-        url: `/admin/organisations/${req.params.orgId}/teams`
+        url: `/admin/organisations/${req.params.orgId}/teams?removeAdmin=true`
       });
 
       req.sessionModel.set('userResults', userResults);

--- a/views/pages/organisation/user-edit.html
+++ b/views/pages/organisation/user-edit.html
@@ -63,13 +63,13 @@
         }) }}
         {{ hmpoSelect(ctx, {
             id: "teamSelect",
-            key: "teamSelect",
             label: {
                 text: translate("fields.teamSelect.label"),
                 classes: "govuk-label--s"
             },
             classes: "govuk-!-width-one-half",
-            items: teamsToShow })
+            items: teamsToShow,
+            placeholder: true })
         }}
 
         <div class="govuk-button-group">


### PR DESCRIPTION
- updated user create and edit controller to retrieve only non admin teams for teamSelect, restricting org admin to not create user as org admins
- Also added placeholder to be true for `teamSelect` edit screen when org admin tries to edit another org admin it was preselecting team which the requesting org admin is able to view (silently removing other org admin to preselected team). These changes resolves the issue not preselecting team from `/assignable-teams`. org admin on submit will get error message to `Select a Team` for user.