### PR TITLE
LEV-317: Add aria-describedby label to system number hint.

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -42,7 +42,7 @@
       "label": "System number from birth certificate"
     },
     "birth-system-number-hint": {
-      "summaryText": "What is the system number?",
+      "summaryHtml": "<div aria-labelledby=\"system-number-hint\">What is the system number?</div>",
       "html": "<img src=\"/public/images/system-number-hint.png\" alt=\"The system number is a nine digit number located in the bottom left corner of the birth certificate\" title=\"Where to find the system number on a birth certificate\"/>"
     },
     "death-system-number": {

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -14,7 +14,6 @@
     {% set sumText = rawSumText if rawSumText != detailsKey + ".summaryText" else undefined %}
 
 
-
     {{ hmpoDetails({
         id: fieldName + "-hint",
         summaryText: sumText if sumText and not sumHtml,

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -17,7 +17,7 @@
 
     {{ hmpoDetails({
         id: fieldName + "-hint",
-        summaryText: sumText if sumText,
+        summaryText: sumText if sumText and not sumHtml,
         summaryHtml: sumHtml if sumHtml,
         html: hmpoHtml(ctx().translate(detailsKey + ".html"))
     }) }}

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -9,7 +9,7 @@
 
     {{ hmpoDetails({
         id: fieldName + "-hint",
-        summaryText: ctx().translate(detailsKey + ".summaryText"),
+        summaryText: hmpoHtml(ctx().translate(detailsKey + ".summaryHtml")),
         html: hmpoHtml(ctx().translate(detailsKey + ".html"))
     }) }}
 {% endmacro %}

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -7,9 +7,18 @@
 
     {% set detailsKey = "fields." + detailsKey or fieldName + "-hint" %}
 
+
+    {% set rawSumHtml = ctx().translate(detailsKey + ".summaryHtml") %}
+    {% set sumHtml = rawSumHtml if rawSumHtml != detailsKey + ".summaryHtml" else undefined %}
+    {% set rawSumText = ctx().translate(detailsKey + ".summaryText") %}
+    {% set sumText = rawSumText if rawSumText != detailsKey + ".summaryText" else undefined %}
+
+
+
     {{ hmpoDetails({
         id: fieldName + "-hint",
-        summaryText: hmpoHtml(ctx().translate(detailsKey + ".summaryHtml")),
+        summaryText: sumText if sumText,
+        summaryHtml: sumHtml if sumHtml,
         html: hmpoHtml(ctx().translate(detailsKey + ".html"))
     }) }}
 {% endmacro %}


### PR DESCRIPTION
Changed summaryText to summaryHtml in deafult.json. Added label pointing to "details" element as it sounds more natural when using a screen reader.

Changed lev-system-number.njk to render html if it exists, otherwise render text. 

Used aria-labelledby instead of aria-describedby as it is getting the hint information from an element that is hidden by default, describedby doesn't read the information that is hidden.