### PR TITLE
LEV-317-add-aria-describedby

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -42,7 +42,7 @@
       "label": "System number from birth certificate"
     },
     "birth-system-number-hint": {
-      "summaryText": "What is the system number?",
+      "summaryHtml": "<div aria-labelledby=\"system-number-hint\">What is the system number?</div>",
       "html": "<img src=\"/public/images/system-number-hint.png\" alt=\"The system number is a nine digit number located in the bottom left corner of the birth certificate\" title=\"Where to find the system number on a birth certificate\"/>"
     },
     "death-system-number": {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -49,21 +49,21 @@
       "label": "System number from death certificate"
     },
     "death-system-number-hint": {
-      "summaryText": "What is the system number?",
+      "summaryHtml": "<div aria-labelledby=\"system-number-hint\">What is the system number?</div>",
       "html": "<img src=\"/public/images/system-number-hint.png\" alt=\"The system number is a nine digit number located in the bottom left corner of the death certificate\" title=\"Where to find the system number on a death certificate\"/>"
     },
     "marriage-system-number": {
       "label": "System number from marriage certificate"
     },
     "marriage-system-number-hint": {
-      "summaryText": "What is the system number?",
+      "summaryHtml": "<div aria-labelledby=\"system-number-hint\">What is the system number?</div>",
       "html": "<img src=\"/public/images/system-number-hint.png\" alt=\"The system number is a nine digit number located in the bottom left corner of the marriage certificate\" title=\"Where to find the system number on a marriage certificate\"/>"
     },
     "partnership-system-number": {
       "label": "System number from civil partnership certificate"
     },
     "partnership-system-number-hint": {
-      "summaryText": "What is the system number?",
+      "summaryHtml": "<div aria-labelledby=\"system-number-hint\">What is the system number?</div>",
       "html": "<img src=\"/public/images/system-number-hint.png\" alt=\"The system number is a nine digit number located in the bottom left corner of the civil partnership certificate\" title=\"Where to find the system number on a civil partnership certificate\"/>"
     },
     "surname": {

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -7,13 +7,6 @@
 
     {% set detailsKey = "fields." + detailsKey or fieldName + "-hint" %}
 
-
-    {% set rawSumHtml = ctx().translate(detailsKey + ".summaryHtml") %}
-    {% set sumHtml = rawSumHtml if rawSumHtml != detailsKey + ".summaryHtml" else undefined %}
-    {% set rawSumText = ctx().translate(detailsKey + ".summaryText") %}
-    {% set sumText = rawSumText if rawSumText != detailsKey + ".summaryText" else undefined %}
-
-
     {{ hmpoDetails({
         id: fieldName + "-hint",
         summaryHtml: ctx().translate(detailsKey + ".summaryHtml"),

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -7,9 +7,17 @@
 
     {% set detailsKey = "fields." + detailsKey or fieldName + "-hint" %}
 
+
+    {% set rawSumHtml = ctx().translate(detailsKey + ".summaryHtml") %}
+    {% set sumHtml = rawSumHtml if rawSumHtml != detailsKey + ".summaryHtml" else undefined %}
+    {% set rawSumText = ctx().translate(detailsKey + ".summaryText") %}
+    {% set sumText = rawSumText if rawSumText != detailsKey + ".summaryText" else undefined %}
+
+
     {{ hmpoDetails({
         id: fieldName + "-hint",
-        summaryText: ctx().translate(detailsKey + ".summaryText"),
+        summaryText: sumText if sumText and not sumHtml,
+        summaryHtml: sumHtml if sumHtml,
         html: hmpoHtml(ctx().translate(detailsKey + ".html"))
     }) }}
 {% endmacro %}

--- a/views/components/lev-system-number.njk
+++ b/views/components/lev-system-number.njk
@@ -16,8 +16,7 @@
 
     {{ hmpoDetails({
         id: fieldName + "-hint",
-        summaryText: sumText if sumText and not sumHtml,
-        summaryHtml: sumHtml if sumHtml,
+        summaryHtml: ctx().translate(detailsKey + ".summaryHtml"),
         html: hmpoHtml(ctx().translate(detailsKey + ".html"))
     }) }}
 {% endmacro %}


### PR DESCRIPTION
Changed summaryText to summaryHtml in deafult.json. Added label pointing to "details" element as it sounds more natural when using a screen reader.

Changed lev-system-number.njk to render html if it exists, otherwise render text.

Used aria-labelledby instead of aria-describedby as it is getting the hint information from an element that is hidden by default, describedby doesn't read the information that is hidden.