### PR TITLE
organisation link updated on landing page

### DIFF
--- a/views/pages/home/index.html
+++ b/views/pages/home/index.html
@@ -72,7 +72,7 @@
                     classes: 'govuk-!-padding-left-3',
                     navigation: [{
                         href: "/admin/organisations",
-                        text: "Organisation(s)"
+                        text: "Organisations, Teams and Users"
                     }]
                 }) }}
             </div>


### PR DESCRIPTION
The wording of organisation link on landing page is updated to **Organisations, Teams and Users**