### PR TITLE
LEV-894 - Adding facility for a feedback banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 IAM_USER=user.that.can.access.iam
 ROLES=birth,death,user-management
+
+# All of these should be set (including valid ISO8601 dates) in order to display a phase banner in the header.
+FEEDBACK_CONTENT_HTML='This is a newly designed service - your <a href="#">feedback</a> will help use improve it.'
+FEEDBACK_START="2025-07-01 00:00:00"
+FEEDBACK_END="2025-08-30 23:59:59"

--- a/app.js
+++ b/app.js
@@ -18,6 +18,8 @@ const { router, app } = setup(options);
 const nunjucksEnv = app.get('nunjucksEnv');
 
 nunjucksEnv.addFilter('relativeDateTime', require('./filters/relativeDateTimeFilter'));
+nunjucksEnv.addGlobal('displayFeedbackBanner', require('./helpers/feedbackBanner'));
+nunjucksEnv.addGlobal('feedbackContentHtml', process.env.FEEDBACK_CONTENT_HTML);
 
 router.use((req, res, next) => {
   if(!req.url.toLowerCase().includes('syops') && !req.url.toLowerCase().includes('metrics') && !req.url.toLowerCase().includes('access-test') && !req.url.toLowerCase().includes('public') && !req.url.toLowerCase().includes('assets')) {

--- a/helpers/feedbackBanner.js
+++ b/helpers/feedbackBanner.js
@@ -1,0 +1,12 @@
+/**
+ * Helper function called that Nunjucks can use to determine whether to display a feedback banner.
+ * @returns {*|boolean}
+ */
+const displayFeedbackBanner = () => {
+  const startDate = new Date(process.env.FEEDBACK_START);
+  const endDate = new Date(process.env.FEEDBACK_END);
+  const currentDate = new Date();
+  return process.env.FEEDBACK_CONTENT_HTML && currentDate >= startDate && currentDate <= endDate;
+};
+
+module.exports = displayFeedbackBanner;

--- a/helpers/feedbackBanner.js
+++ b/helpers/feedbackBanner.js
@@ -6,7 +6,7 @@ const displayFeedbackBanner = () => {
   const startDate = new Date(process.env.FEEDBACK_START);
   const endDate = new Date(process.env.FEEDBACK_END);
   const currentDate = new Date();
-  return process.env.FEEDBACK_CONTENT_HTML && currentDate >= startDate && currentDate <= endDate;
+  return !!process.env.FEEDBACK_CONTENT_HTML && currentDate >= startDate && currentDate <= endDate;
 };
 
 module.exports = displayFeedbackBanner;

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -434,5 +434,5 @@
       "regex": "Email domain can only include letters, numbers, hyphens and full stops (-.)"
     }
   },
-  "footer": "Your feedback will help us improve this service. Email us <a href=\"mailto:ITnowServiceDesk@homeoffice.gov.uk?subject=LEV%20Feedback\">ITnowServiceDesk@homeoffice.gov.uk</a>"
+  "footer": "Your feedback will help us improve this service. Email us <a class=\"govuk-link\" href=\"mailto:ITnowServiceDesk@homeoffice.gov.uk?subject=LEV%20Feedback\">ITnowServiceDesk@homeoffice.gov.uk</a>"
 }

--- a/test/unit/helpers/feedbackBanner.test.js
+++ b/test/unit/helpers/feedbackBanner.test.js
@@ -1,0 +1,64 @@
+const displayFeedbackBanner = require('../../../helpers/feedbackBanner');
+
+describe('displayFeedbackBanner()', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.useRealTimers();
+  });
+
+  it('returns true when FEEDBACK_CONTENT_HTML is set and current date is within range', () => {
+    process.env.FEEDBACK_CONTENT_HTML = '<p>Feedback</p>';
+    process.env.FEEDBACK_START = '2025-07-01 00:00:00';
+    process.env.FEEDBACK_END = '2025-07-31 23:59:59';
+    jest.setSystemTime(new Date('2025-07-11 12:00:00'));
+    expect(displayFeedbackBanner()).toBe(true);
+  });
+
+  it('returns false when FEEDBACK_CONTENT_HTML is set but current date is before range', () => {
+    process.env.FEEDBACK_CONTENT_HTML = '<p>Feedback</p>';
+    process.env.FEEDBACK_START = '2025-07-12 00:00:00';
+    process.env.FEEDBACK_END = '2025-07-31 23:59:59';
+    jest.setSystemTime(new Date('2025-07-11 12:00:00'));
+    expect(displayFeedbackBanner()).toBe(false);
+  });
+
+  it('returns false when FEEDBACK_CONTENT_HTML is set but current date is after range', () => {
+    process.env.FEEDBACK_CONTENT_HTML = '<p>Feedback</p>';
+    process.env.FEEDBACK_START = '2025-07-01 00:00:00';
+    process.env.FEEDBACK_END = '2025-07-10 23:59:59';
+    jest.setSystemTime(new Date('2025-07-11 12:00:00'));
+    expect(displayFeedbackBanner()).toBe(false);
+  });
+
+  it('returns false when FEEDBACK_CONTENT_HTML is not set', () => {
+    process.env.FEEDBACK_CONTENT_HTML = '';
+    process.env.FEEDBACK_START = '2025-07-01 00:00:00';
+    process.env.FEEDBACK_END = '2025-07-31 23:59:59';
+    jest.setSystemTime(new Date('2025-07-11 12:00:00'));
+    expect(displayFeedbackBanner()).toBe(false);
+  });
+
+  it('returns false when FEEDBACK_START is invalid', () => {
+    process.env.FEEDBACK_CONTENT_HTML = '<p>Feedback</p>';
+    process.env.FEEDBACK_START = 'invalid-date';
+    process.env.FEEDBACK_END = '2025-07-31 23:59:59';
+    jest.setSystemTime(new Date('2025-07-11 12:00:00'));
+    expect(displayFeedbackBanner()).toBe(false);
+  });
+
+  it('returns false when FEEDBACK_END is invalid', () => {
+    process.env.FEEDBACK_CONTENT_HTML = '<p>Feedback</p>';
+    process.env.FEEDBACK_START = '2025-07-01 00:00:00';
+    process.env.FEEDBACK_END = 'invalid-date';
+    jest.setSystemTime(new Date('2025-07-11 12:00:00'));
+    expect(displayFeedbackBanner()).toBe(false);
+  });
+});

--- a/views/components/lev-header.njk
+++ b/views/components/lev-header.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
 {% macro levHeader(params) %}
 
 <header class="govuk-header {{ params.classes if params.classes }}" role="banner" data-module="govuk-header"
@@ -50,6 +52,15 @@
     {% endif %}
   </div>
 </header>
+{% if displayFeedbackBanner() %}
+<div class="govuk-phase-banner govuk-width-container">
+  <p class="govuk-phase-banner__content">
+    <span class="govuk-phase-banner__text">
+      {{ feedbackContentHtml | safe }}
+    </span>
+  </p>
+</div>
+{% endif %}
 
 {% endmacro %}
 


### PR DESCRIPTION
This PR enables us to add a feedback banner (using the [GDS Phase banner ](https://design-system.service.gov.uk/components/phase-banner/)component) to the UI. It doesn't include the "phase" part, but [a discussion on the component](https://github.com/alphagov/govuk-design-system-backlog/issues/57#issuecomment-887478246) indicates that at least one other service has achieved GDS certification without it.

It's controlled using environment variables so we can set a date for it to appear from and to, without having to depend on a code deployment to push it out.

An example of it in situ:

<img width="1027" height="178" alt="image" src="https://github.com/user-attachments/assets/7d32cbb5-9190-428b-b02c-16daf8d2d90a" />
